### PR TITLE
Dev

### DIFF
--- a/filmulator-gui/filmulator-gui.pro
+++ b/filmulator-gui/filmulator-gui.pro
@@ -94,7 +94,7 @@ QMAKE_CXXFLAGS += -std=c++11 -DTOUT -O3 -fprefetch-loop-arrays -fopenmp
 #QMAKE_CFLAGS_DEBUG += -DTOUT -O3 -fprefetch-loop-arrays -fopenmp
 QMAKE_LFLAGS += -std=c++11 -O3 -fopenmp
 
-LIBS += -lpthread -ltiff -lexiv2 -ljpeg -lraw -lgomp
+LIBS += -lpthread -ltiff -lexiv2 -ljpeg -lraw_r -lgomp
 
 QT += sql core quick qml widgets
 

--- a/filmulator-gui/qml/filmulator-gui/Edit.qml
+++ b/filmulator-gui/qml/filmulator-gui/Edit.qml
@@ -62,15 +62,13 @@ SplitView {
             property real centerY: (contentY + bottomImage.height*Math.min(bottomImage.scale, fitScaleY)/2) / bottomImage.scale
             Rectangle {
                 id: imageRect
-                width: Math.max(bottomImage.width*bottomImage.scale,parent.width);
-                height: Math.max(bottomImage.height*bottomImage.scale,parent.height);
+                //The dimensions here need to be floor because it was yielding non-pixel widths.
+                //That caused the child images to be offset by fractional pixels at 1:1 scale when the
+                // image is smaller than the flickable in one or more directions.
+                width: Math.floor(Math.max(bottomImage.width*bottomImage.scale,parent.width));
+                height: Math.floor(Math.max(bottomImage.height*bottomImage.scale,parent.height));
                 transformOrigin: Item.TopLeft
                 color: "#000000"
-                /*
-                  If the image is too small, we need to make sure that it's pixel aligned at fit scale.
-                  The flickable is currently set to pixel aligned, but the rectangle might not be an
-                  even width (or odd width; not sure).
-                  */
                 Image {
                     anchors.centerIn: parent
                     id: topImage

--- a/filmulator-gui/qml/filmulator-gui/Edit.qml
+++ b/filmulator-gui/qml/filmulator-gui/Edit.qml
@@ -42,6 +42,7 @@ SplitView {
             contentHeight: Math.max(bottomImage.height*bottomImage.scale, this.height);
             flickableDirection: Flickable.HorizontalAndVerticalFlick
             clip: true
+            pixelAligned: true
             property real fitScaleX: flicky.width/bottomImage.width
             property real fitScaleY: flicky.height/bottomImage.height
             property real fitScale: Math.min(fitScaleX, fitScaleY)
@@ -65,6 +66,11 @@ SplitView {
                 height: Math.max(bottomImage.height*bottomImage.scale,parent.height);
                 transformOrigin: Item.TopLeft
                 color: "#000000"
+                /*
+                  If the image is too small, we need to make sure that it's pixel aligned at fit scale.
+                  The flickable is currently set to pixel aligned, but the rectangle might not be an
+                  even width (or odd width; not sure).
+                  */
                 Image {
                     anchors.centerIn: parent
                     id: topImage

--- a/filmulator-gui/qml/filmulator-gui/EditTools.qml
+++ b/filmulator-gui/qml/filmulator-gui/EditTools.qml
@@ -246,21 +246,21 @@ SplitView {
                     id: filmSizeSlider
                     title: qsTr("Film Area")
                     tooltipText: qsTr("Larger sizes emphasize smaller details and flatten contrast; smaller sizes emphasize larger regional contrasts. This has the same effect as film size in real film. If venturing into Medium or Large Format, keep the Drama slider below 40 to prevent overcooking.")
-                    minimumValue: 10
-                    maximumValue: 300
-                    value: Math.sqrt(paramManager.filmArea)
-                    defaultValue: Math.sqrt(root.defaultFilmSize)
+                    minimumValue: 1.2//less than log of 10
+                    maximumValue: 6//greater than log of 300
+                    value: Math.log(Math.sqrt(paramManager.filmArea))
+                    defaultValue: Math.log(Math.sqrt(root.defaultFilmSize))
                     //The following thresholds are 24mmx65mm and twice 6x9cm film's
                     // areas, respectively.
-                    valueText: (value*value < 1560) ? "SF" : (value*value < 9408) ? "MF" : "LF"
+                    valueText: (Math.exp(value*2) < 1560) ? "SF" : (Math.exp(value*2) < 9408) ? "MF" : "LF"
                     onValueChanged: {
-                        paramManager.filmArea = value*value
+                        paramManager.filmArea = Math.exp(value*2)//exp(value)*exp(value)
                     }
                     onEditComplete: paramManager.writeback()
                     Connections {
                         target: paramManager
                         onFilmAreaChanged: {
-                            filmSizeSlider.value = Math.sqrt(paramManager.filmArea)
+                            filmSizeSlider.value = Math.log(Math.sqrt(paramManager.filmArea))
                         }
                     }
                     Component.onCompleted: {

--- a/filmulator-gui/qml/filmulator-gui/Import.qml
+++ b/filmulator-gui/qml/filmulator-gui/Import.qml
@@ -126,7 +126,7 @@ Rectangle {
         ImportTextEntry {
             id: dirStructureEntry
             title: qsTr("Directory Structure")
-            tooltipText: qsTr("Enter with y's, M's, and d's, slashes, and dashes the desired structure. example: \"/yyyy/MM/yyyy-MM-dd/\"")
+            tooltipText: qsTr("Enter with y's, M's, and d's, slashes, and dashes the desired structure. You can use single quotes to include words in the structure. For example:\n\"/yyyy/MM/yyyy-MM-dd/\"\n\"/yyyy/'Alaska'/yyyy-MM-dd/\"")
             enteredText: settings.getDirConfig()//"/yyyy/MM/yyyy-MM-dd/"
             onEnteredTextChanged: {
                 importModel.dirConfig = enteredText

--- a/filmulator-gui/ui/parameterManager.cpp
+++ b/filmulator-gui/ui/parameterManager.cpp
@@ -922,7 +922,7 @@ void ParameterManager::loadParams(QString imageID)
     //Next is highlights (highlight recovery)
     nameCol = rec.indexOf("ProcThighlightRecovery");
     if (-1 == nameCol) { std::cout << "paramManager ProcThighlightRecovery" << endl; }
-    const bool temp_highlights = query.value(nameCol).toInt();
+    const int temp_highlights = query.value(nameCol).toInt();
     if (temp_highlights != m_highlights)
     {
         //cout << "ParameterManager::loadParams highlights" << endl;


### PR DESCRIPTION
Fix crashes when importing and editing simultaneously by using thread-safe libraw

Fix half pixel misalignment in editor when photo is smaller than editor viewport

Make the film area slider logarithmic WRT the linear dimensions

Elaborate on the directory structure tooltip in the import tab