### PR TITLE
Dev

### DIFF
--- a/filmulator-gui/core/exposure.cpp
+++ b/filmulator-gui/core/exposure.cpp
@@ -19,8 +19,16 @@
 #include "filmSim.hpp"
 
 matrix<float> exposure(matrix<float> input_image, float crystals_per_pixel,
-        int rolloff_boundary)
+        float rolloff_boundary)
 {
+    if (rolloff_boundary < 1.0f)
+    {
+        rolloff_boundary = 1.0f;
+    }
+    else if(rolloff_boundary > 65534.0f)
+    {
+        rolloff_boundary = 65534.0f;
+    }
     int nrows = input_image.nr();
     int ncols = input_image.nc();
     float input;
@@ -33,7 +41,7 @@ matrix<float> exposure(matrix<float> input_image, float crystals_per_pixel,
     {
         for(int col = 0; col<ncols; col++)
         {
-            input=input_image(row,col);
+            input = max(0.0f,input_image(row,col));
             if(input > rolloff_boundary)
                 input = 65535-(crystal_headroom*crystal_headroom/
                         (input+crystal_headroom-rolloff_boundary));

--- a/filmulator-gui/core/filmSim.hpp
+++ b/filmulator-gui/core/filmSim.hpp
@@ -65,11 +65,11 @@ struct filmulateParams {//TODO: adjust variable names.
     float sigmaConst;
     float layerMixConst;
     float layerTimeDivisor;
-    int rolloffBoundary;
+    float rolloffBoundary;
 };
 
 matrix<float> exposure(matrix<float> input_image, float crystals_per_pixel,
-        int rolloff_boundary);
+        float rolloff_boundary);
 
 //Equalizes the concentration of developer across the reservoir and all pixels.
 void agitate( matrix<float> &developerConcentration, float activeLayerThickness,

--- a/filmulator-gui/core/filmulate.cpp
+++ b/filmulator-gui/core/filmulate.cpp
@@ -54,7 +54,7 @@ bool ImagePipeline::filmulate(matrix<float> &input_image,
     float sigma_const = filmParam.sigmaConst;
     float layer_mix_const = filmParam.layerMixConst;
     float layer_time_divisor = filmParam.layerTimeDivisor;
-    int rolloff_boundary = filmParam.rolloffBoundary;
+    float rolloff_boundary = filmParam.rolloffBoundary;
 
     //Set up timers
     struct timeval initialize_start, development_start, develop_start,

--- a/filmulator-gui/core/imagePipeline.cpp
+++ b/filmulator-gui/core/imagePipeline.cpp
@@ -211,15 +211,14 @@ matrix<unsigned short> ImagePipeline::processImage(ParameterManager * paramManag
             return emptyMatrix();
         }
 
-        //Apply the default tonecurve first, then apply the slider-controlled curve.
         filmLikeLUT.fill( [=](unsigned short in) -> unsigned short
             {
-                float shResult = shadows_highlights(default_tonecurve(float(in)/65535.0),
+                float shResult = shadows_highlights(float(in)/65535.0,
                                                      curvesParam.shadowsX,
                                                      curvesParam.shadowsY,
                                                      curvesParam.highlightsX,
                                                      curvesParam.highlightsY);
-                return 65535*shResult;
+                return 65535*default_tonecurve(shResult);
             }
         );
         matrix<unsigned short> film_curve_image;

--- a/filmulator-gui/core/imagePipeline.cpp
+++ b/filmulator-gui/core/imagePipeline.cpp
@@ -211,15 +211,15 @@ matrix<unsigned short> ImagePipeline::processImage(ParameterManager * paramManag
             return emptyMatrix();
         }
 
-        filmLikeLUT.fill(
-            [=](unsigned short in) -> unsigned short
+        //Apply the default tonecurve first, then apply the slider-controlled curve.
+        filmLikeLUT.fill( [=](unsigned short in) -> unsigned short
             {
-                float shResult = shadows_highlights(float(in)/65535.0,
+                float shResult = shadows_highlights(default_tonecurve(float(in)/65535.0),
                                                      curvesParam.shadowsX,
                                                      curvesParam.shadowsY,
                                                      curvesParam.highlightsX,
                                                      curvesParam.highlightsY);
-                return 65535*default_tonecurve(shResult);
+                return 65535*shResult;
             }
         );
         matrix<unsigned short> film_curve_image;

--- a/filmulator-gui/database/dbSetup.cpp
+++ b/filmulator-gui/database/dbSetup.cpp
@@ -232,6 +232,7 @@ void setupDB(QSqlDatabase *db)
     switch (oldVersion) {
     case 0:
         //Generate a list of 100000 integers for useful purposes
+        /*
         query.exec("CREATE TABLE integers (i integer);");
         query.exec("INSERT INTO integers (i) VALUES (0);");
         query.exec("INSERT INTO integers (i) VALUES (1);");
@@ -251,8 +252,10 @@ void setupDB(QSqlDatabase *db)
                    "CROSS JOIN integers d "
                    "CROSS JOIN integers e "
                    "CROSS JOIN integers f;");
+                   */
         versionString = "PRAGMA user_version = 1;";
     case 1:
+        /*
         query.exec("CREATE VIEW integers5 as "
                    "SELECT 10000*a.i+1000*b.i+100*c.i+10*d.i+e.i as ints "
                    "FROM integers a "
@@ -266,6 +269,7 @@ void setupDB(QSqlDatabase *db)
                    "CROSS JOIN integers b "
                    "CROSS JOIN integers c "
                    "CROSS JOIN integers d;");
+                   */
         versionString = "PRAGMA user_version = 2;";
     case 2:
         query.exec("DROP TABLE QueueTable;");
@@ -276,6 +280,11 @@ void setupDB(QSqlDatabase *db)
                    "QToutput bool,"
                    "QTsearchID varchar unique);");
         versionString = "PRAGMA user_version = 3;";
+    case 3:
+        query.exec("DROP VIEW integers9;");
+        query.exec("DROP VIEW integers4;");
+        query.exec("DROP VIEW integers3;");
+        versionString = "PRAGMA user_version = 4;";
     }
     query.exec(versionString);
     query.exec("COMMIT TRANSACTION;");//finalize the transaction only after writing the version.

--- a/filmulator-gui/database/organizeModel.cpp
+++ b/filmulator-gui/database/organizeModel.cpp
@@ -143,5 +143,3 @@ QString OrganizeModel::getDateTimeString(int unixTimeIn)
     QDateTime tempTime = QDateTime::fromTime_t(unixTimeIn, Qt::OffsetFromUTC, m_timeZone*3600);
     return tempTime.toString("ddd yyyy-MM-dd HH:mm:ss");
 }
-
-//SELECT date(STcaptureTime, 'unixepoch', '-5 hours [the timezone]', COUNT(*) FROM SearchTable GROUP BY date(STcaptureTime, 'unixepoch', '-5 hours');

--- a/filmulator-gui/database/organizeModel.h
+++ b/filmulator-gui/database/organizeModel.h
@@ -34,6 +34,7 @@ public:
     Q_INVOKABLE void setRating(QString searchID, int rating);
     Q_INVOKABLE QString getDateTimeString(int unixTimeIn);
     Q_INVOKABLE QDate getSelectedDate();
+    Q_INVOKABLE QString getSelectedYMDString();
 
     DateHistogramModel *dateHistogram = new DateHistogramModel;
 

--- a/filmulator-gui/database/organizeProperties.cpp
+++ b/filmulator-gui/database/organizeProperties.cpp
@@ -59,6 +59,7 @@ void OrganizeModel::setMinMaxCaptureTime(QDate captureTimeIn)
     maxCaptureTime_i = evening.toTime_t();
     emit minCaptureTimeChanged();
     emit maxCaptureTimeChanged();
+    emit captureDateChanged();
     emit organizeFilterChanged();
 }
 void OrganizeModel::setMinMaxCaptureTimeString(QString captureTimeIn)
@@ -79,6 +80,13 @@ QDate OrganizeModel::getSelectedDate()
 {
     return QDateTime(minCaptureTime, QTime(0,0,0,0), Qt::OffsetFromUTC, m_timeZone*3600).date();
 }
+
+QString OrganizeModel::getSelectedYMDString()
+{
+    QDate selectedDate = getSelectedDate();
+    return selectedDate.toString("yyyy/MM/dd");
+}
+
 
 void OrganizeModel::setMinImportTime(QDate importTimeIn)
 {
@@ -263,6 +271,7 @@ void OrganizeModel::setTimeZone(int timeZoneIn)
     setMinProcessedTime(minProcessedTime);
     setMaxProcessedTime(maxProcessedTime);
     emit organizeFilterChanged();
+    emit captureDateChanged();
 
     //The date histogram must only be updated after it was initialized.
     if (dateHistogramSet)

--- a/filmulator-gui/qml/filmulator-gui/Edit.qml
+++ b/filmulator-gui/qml/filmulator-gui/Edit.qml
@@ -24,6 +24,7 @@ SplitView {
     property alias defaultVibrance: editTools.defaultVibrance
     property alias defaultSaturation: editTools.defaultSaturation
     property alias defaultOverdriveEnabled: editTools.defaultOverdriveEnabled
+    property alias defaultHighlightRolloff: editTools.defaultHighlightRolloff
 
     signal tooltipWanted(string text, int x, int y)
     signal imageURL(string newURL)

--- a/filmulator-gui/qml/filmulator-gui/EditTools.qml
+++ b/filmulator-gui/qml/filmulator-gui/EditTools.qml
@@ -45,7 +45,7 @@ SplitView {
         Canvas {
             id: mainHistoCanvas
             anchors.fill: parent
-            property int lineWidth: 1 * uiScale
+            property int lineWidth: 2 * uiScale
             property real alpha: 1.0
             property int padding: 5 * uiScale
             canvasSize.width: root.maxWidth
@@ -220,7 +220,7 @@ SplitView {
                     //It seems that since this is in a layout, you can't bind dimensions or locations.
                     // Makes sense, given that the layout is supposed to abstract that away.
                     height: 30 * uiScale
-                    property int lineWidth: 1 * uiScale
+                    property int lineWidth: 2 * uiScale
                     property real alpha: 1.0
                     property int padding: 3 * uiScale
 
@@ -359,7 +359,7 @@ SplitView {
                     //It seems that since this is in a layout, you can't bind dimensions or locations.
                     // Makes sense, given that the layout is supposed to abstract that away.
                     height: 30 * uiScale
-                    property int lineWidth: 1 * uiScale
+                    property int lineWidth: 2 * uiScale
                     property real alpha: 1.0
                     property int padding: 3 * uiScale
 

--- a/filmulator-gui/qml/filmulator-gui/EditTools.qml
+++ b/filmulator-gui/qml/filmulator-gui/EditTools.qml
@@ -254,7 +254,7 @@ SplitView {
                 ToolSlider {
                     id: rolloffSlider
                     title: qsTr("Highlight Rolloff Point")
-                    tooltipText: qsTr("Controls the inflection point for the highlight rolloff. Below this point the exposure of the film is linear, and above it the brightness increase gradually slows.\nIt's mostly useful for dealing with clipped color channels that are oversaturated. Reduce this slider to about 0.5 and watch the highlight colors gently fade out.")
+                    tooltipText: qsTr("Sets the point above which the highlights gently stop getting brighter. This controls the saturation of the highlights, and only has a significant effect at high drama settings when the highlights get strongly darkened.\nIf you have a photo with no highlight clipping and none of it extends beyond the right of the prefilm histogram, feel free to raise this all the way to 1.\nIf you have highlight clipping and there are unpleasant color shifts, lower this to taste.")
                     minimumValue: 1
                     maximumValue: 65535
                     value: paramManager.rolloffBoundary

--- a/filmulator-gui/qml/filmulator-gui/Organize.qml
+++ b/filmulator-gui/qml/filmulator-gui/Organize.qml
@@ -220,7 +220,7 @@ SplitView {
                     ToolTip {
                         id: dateHistoTooltip
                         anchors.fill: parent
-                        tooltipText:  parent.selectedDate + '\n' + qsTr('Date: ') + parent.theDate + '\n' + qsTr('Count: ') + parent.count
+                        tooltipText: qsTr('Date: ') + parent.theDate + '\n' + qsTr('Count: ') + parent.count
                         milliSecondDelay: 0
                         Component.onCompleted: {
                             dateHistoTooltip.tooltipWanted.connect(root.tooltipWanted)

--- a/filmulator-gui/qml/filmulator-gui/Organize.qml
+++ b/filmulator-gui/qml/filmulator-gui/Organize.qml
@@ -182,17 +182,21 @@ SplitView {
                 cellHeight: dateHistogram.height
                 boundsBehavior: Flickable.StopAtBounds
 
+                property string selectedDate
+
                 delegate: Rectangle {
                     id: dateHistoDelegate
                     width: 5.01 * uiScale //This has to be sliiightly bigger to ensure overlap
-                    property string date: thedate
+                    property string selectedDate: dateHistoView.selectedDate
+                    property string theDate: thedate
                     property int count: thecount
                     property string yearMonthString: yearmonth
                     property int month: themonth
                     property int day: theday
                     property real contentAmount: Math.min(1, (count > 0) ? (Math.log(count)+1)/16 : 0)
+                    property bool sel: selectedDate == theDate
                     height: dateHistogram.height
-                    color: (1===themonth%2) ? Colors.darkGrayH : Colors.darkGrayL
+                    color: (1===themonth%2) ? (sel ? Colors.darkOrangeH : Colors.darkGrayH) : (sel ? Colors.darkOrangeL : Colors.darkGrayL)
                     clip: true
                     Text {
                         id: monthYearLabel
@@ -210,13 +214,13 @@ SplitView {
                         width: parent.width
                         y: parent.height*(1-contentAmount)
                         height: parent.height*contentAmount
-                        color: Colors.lightOrange
+                        color: parent.sel ? Colors.brightOrange : Colors.lightOrange
                     }
 
                     ToolTip {
                         id: dateHistoTooltip
                         anchors.fill: parent
-                        tooltipText:  qsTr('Date: ') + parent.date + '\n' + qsTr('Count: ') + parent.count
+                        tooltipText:  parent.selectedDate + '\n' + qsTr('Date: ') + parent.theDate + '\n' + qsTr('Count: ') + parent.count
                         milliSecondDelay: 0
                         Component.onCompleted: {
                             dateHistoTooltip.tooltipWanted.connect(root.tooltipWanted)
@@ -226,10 +230,15 @@ SplitView {
                         id: dateChanger
                         anchors.fill: parent
                         onDoubleClicked: {
-                            console.log("Date set: ")
-                            console.log(parent.date)
-                            organizeModel.setMinMaxCaptureTimeString(parent.date)
+                            organizeModel.setMinMaxCaptureTimeString(parent.theDate)
                         }
+                    }
+                }
+
+                Connections {
+                    target: organizeModel
+                    onCaptureDateChanged: {
+                        dateHistoView.selectedDate = organizeModel.getSelectedYMDString()
                     }
                 }
 

--- a/filmulator-gui/qml/filmulator-gui/colors.js
+++ b/filmulator-gui/qml/filmulator-gui/colors.js
@@ -13,9 +13,12 @@ var darkGray = "#303030"
 var darkGrayL = "#202020"
 var blackGray = "#101010"
 var whiteOrange = "#FFEEDD" //good for orange on black text, strong highlights on orange things
+var brighterOrange = "#FFCCAA" //good for slight oranging of white things to indicate effect
 var brightOrange = "#FFBB66" //good for subtle highlights on orange things
 var lightOrange = "#FF9922" //good for thin lines
 var medOrange = "#FF8800" //perfect middle orange
+var darkOrangeH = "#584C40" //dark orange for highlighting darkGrayH
+var darkOrangeL = "#403020" //dark orange for highlighting darkGrayL
 var weakOrange = "#A87848" //Low saturation for orange bleeding around gray
 
 var transDarkGray = "#EE303030" //for tooltip backgrounds

--- a/filmulator-gui/qml/filmulator-gui/generateHistogram.js
+++ b/filmulator-gui/qml/filmulator-gui/generateHistogram.js
@@ -80,7 +80,7 @@ function generateHistogram(histNumber,ctx,width,height,padding,lineWidth,uiScale
     }
     ctx.lineTo(endx,starty);
     ctx.closePath();
-    ctx.strokeStyle = "#0000FF"
+    ctx.strokeStyle = "#3030FF"
     ctx.stroke();
 
     ctx.strokeStyle = "#000000";

--- a/filmulator-gui/qml/filmulator-gui/gui_components/ImportTextEntry.qml
+++ b/filmulator-gui/qml/filmulator-gui/gui_components/ImportTextEntry.qml
@@ -20,7 +20,7 @@ Rectangle {
     Item {
         id: labelBox
         width: parent.width - 2*__padding
-        height: 25 * uiScale - __padding
+        height: 25 * uiScale
         x: __padding
         y: __padding
         Text {

--- a/filmulator-gui/qml/filmulator-gui/main.qml
+++ b/filmulator-gui/qml/filmulator-gui/main.qml
@@ -77,6 +77,7 @@ ApplicationWindow {
                 property real defaultVibrance: 0
                 property real defaultSaturation: 0
                 property bool defaultOverdriveEnabled: false
+                property real defaultHighlightRolloff: 51275
 
                 title: qsTr("Filmulate")
                 Edit {
@@ -95,6 +96,7 @@ ApplicationWindow {
                     defaultVibrance: editorTab.defaultVibrance
                     defaultSaturation: editorTab.defaultSaturation
                     defaultOverdriveEnabled: editorTab.defaultOverdriveEnabled
+                    defaultHighlightRolloff: editorTab.defaultHighlightRolloff
 
                     Component.onCompleted: {
                         editItem.tooltipWanted.connect(root.tooltipWanted)

--- a/filmulator-gui/ui/parameterManager.cpp
+++ b/filmulator-gui/ui/parameterManager.cpp
@@ -404,7 +404,7 @@ void ParameterManager::setLayerTimeDivisor(float layerTimeDivisor)
     paramChangeWrapper(QString("setLayerTimeDivisor"));
 }
 
-void ParameterManager::setRolloffBoundary(int rolloffBoundary)
+void ParameterManager::setRolloffBoundary(float rolloffBoundary)
 {
     QMutexLocker paramLocker(&paramMutex);
     m_rolloffBoundary = rolloffBoundary;
@@ -1142,7 +1142,7 @@ void ParameterManager::loadParams(QString imageID)
     //Rolloff boundary. This is where highlights start to roll off.
     nameCol = rec.indexOf("ProcTrolloffBoundary");
     if (-1 == nameCol) { std::cout << "paramManager ProcTrolloffBoundary" << endl; }
-    const int temp_rolloffBoundary = query.value(nameCol).toInt();
+    const float temp_rolloffBoundary = query.value(nameCol).toFloat();
     if (temp_rolloffBoundary != m_rolloffBoundary)
     {
         //cout << "ParameterManager::loadParams rolloffBoundary" << endl;

--- a/filmulator-gui/ui/parameterManager.h
+++ b/filmulator-gui/ui/parameterManager.h
@@ -66,7 +66,7 @@ struct FilmParams {
     float sigmaConst;
     float layerMixConst;
     float layerTimeDivisor;
-    int rolloffBoundary;
+    float rolloffBoundary;
 };
 
 struct BlackWhiteParams {
@@ -128,7 +128,7 @@ class ParameterManager : public QObject
     Q_PROPERTY(float sigmaConst                    MEMBER m_sigmaConst                    WRITE setSigmaConst                    NOTIFY sigmaConstChanged)
     Q_PROPERTY(float layerMixConst                 MEMBER m_layerMixConst                 WRITE setLayerMixConst                 NOTIFY layerMixConstChanged)
     Q_PROPERTY(float layerTimeDivisor              MEMBER m_layerTimeDivisor              WRITE setLayerTimeDivisor              NOTIFY layerTimeDivisorChanged)
-    Q_PROPERTY(int rolloffBoundary                 MEMBER m_rolloffBoundary               WRITE setRolloffBoundary               NOTIFY rolloffBoundaryChanged)
+    Q_PROPERTY(float rolloffBoundary                 MEMBER m_rolloffBoundary               WRITE setRolloffBoundary               NOTIFY rolloffBoundaryChanged)
 
     //Whitepoint & Blackpoint
     Q_PROPERTY(float blackpoint MEMBER m_blackpoint WRITE setBlackpoint NOTIFY blackpointChanged)
@@ -247,7 +247,7 @@ protected:
     float m_sigmaConst;
     float m_layerMixConst;
     float m_layerTimeDivisor;
-    int m_rolloffBoundary;
+    float m_rolloffBoundary;
 
     //Whitepoint & Blackpoint
     float m_blackpoint;
@@ -306,7 +306,7 @@ protected:
     void setSigmaConst(float);
     void setLayerMixConst(float);
     void setLayerTimeDivisor(float);
-    void setRolloffBoundary(int);
+    void setRolloffBoundary(float);
 
     //Whitepoint & Blackpoint
     void setBlackpoint(float);


### PR DESCRIPTION
Add highlight rolloff control.

This is beneficial for handling clipped highlights. If you have nothing clipped, turn it all the way to 1. If highlights are clipped in an ugly way, turn it down some.