### PR TITLE
Dev

### DIFF
--- a/filmulator-gui/database/dbSetup.cpp
+++ b/filmulator-gui/database/dbSetup.cpp
@@ -291,6 +291,9 @@ void setupDB(QSqlDatabase *db)
                    "ADD COLUMN STimportStartTime integer;");
         query.exec("UPDATE SearchTable SET STimportStartTime = STimportTime;");
         versionString = "PRAGMA user_version = 5;";
+    case 5:
+        query.exec("UPDATE SearchTable SET STrating = min(5,max(0,STrating));");
+        versionString = "PRAGMA user_version = 6;";
     }
     query.exec(versionString);
     query.exec("COMMIT TRANSACTION;");//finalize the transaction only after writing the version.

--- a/filmulator-gui/database/queueModel.cpp
+++ b/filmulator-gui/database/queueModel.cpp
@@ -55,6 +55,8 @@ void QueueModel::deQueue(const QString searchID)
     query.prepare("DELETE FROM QueueTable WHERE QTsearchID = ?;");
     query.bindValue(0, searchID);
     query.exec();
+
+    //Update what the largest index is.
     resetIndex();
 
     //Everything after the index in question needs to be decremented.
@@ -71,6 +73,9 @@ void QueueModel::deQueue(const QString searchID)
         queryModel.fetchMore();
     }
     endRemoveRows();
+    //Now tell it to update the indices of all of the rows above that.
+    //We update everything just for thoroughness's sake.
+    emit dataChanged(createIndex(0,0),createIndex(rowCount(),columnCount()));
 
 }
 
@@ -168,4 +173,7 @@ void QueueModel::move(const QString searchID, const int destIndex)
         //Do nothing
     }
     query.exec("END TRANSACTION");
+    //Now tell it to update all of the indices.
+    //We update everything just for thoroughness's sake.
+    emit dataChanged(createIndex(0,0),createIndex(rowCount(),columnCount()));
 }


### PR DESCRIPTION
This fixes a bug where dequeuing multiple images in a row can cause the view to remove the wrong image (though the actual database removed the correct one).

It also pushes a database schema update that fixes ratings for already-existing images from certain Canon cameras. No change in the actual schema itself, though.