### PR TITLE
macstack maintenence for AppleClang 10

### DIFF
--- a/filmulator-gui/core/imagePipeline.cpp
+++ b/filmulator-gui/core/imagePipeline.cpp
@@ -79,7 +79,7 @@ matrix<unsigned short> ImagePipeline::processImage(ParameterManager * paramManag
 
         if (!loadParam.tiffIn && !loadParam.jpegIn && !((HighQuality == quality) && stealData))
         {
-            std::unique_ptr<LibRaw> image_processor = std::make_unique<LibRaw>();
+            std::unique_ptr<LibRaw> image_processor = unique_ptr<LibRaw>(new LibRaw());
 
             //Open the file.
             const char *cstr = loadParam.fullFilename.c_str();

--- a/filmulator-gui/core/whiteBalance.cpp
+++ b/filmulator-gui/core/whiteBalance.cpp
@@ -230,7 +230,7 @@ void optimizeWBMults(std::string file,
                      float &temperature, float &tint)
 {
     //Load wb params from the raw file
-    std::unique_ptr<LibRaw> image_processor = std::make_unique<LibRaw>();
+    std::unique_ptr<LibRaw> image_processor = std::unique_ptr<LibRaw>(new LibRaw());
 
     //Open the file.
     const char *cstr = file.c_str();

--- a/filmulator-gui/filmulator-gui.pro
+++ b/filmulator-gui/filmulator-gui.pro
@@ -124,3 +124,5 @@ INSTALLS += desktop extra
 
 RESOURCES += \
     resources/pixmaps.qrc
+    
+QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.9

--- a/filmulator-gui/filmulator-gui.pro
+++ b/filmulator-gui/filmulator-gui.pro
@@ -112,11 +112,11 @@ HEADERS += \
     database/database.hpp
 
 
-QMAKE_CXXFLAGS += -std=c++14 -DTOUT -O3 -fprefetch-loop-arrays -fopenmp -fno-strict-aliasing -ffast-math
+QMAKE_CXXFLAGS += -std=c++14 -DTOUT -O3 -fprefetch-loop-arrays -lomp -fno-strict-aliasing -ffast-math -I/opt/local/include
 #QMAKE_CFLAGS_DEBUG += -DTOUT -O3 -fprefetch-loop-arrays -fopenmp
-QMAKE_LFLAGS += -std=c++14 -O3 -fopenmp
+QMAKE_LFLAGS += -std=c++14 -O3
 
-LIBS += -lpthread -ltiff -lexiv2 -ljpeg -lraw_r -lgomp -lrtprocess
+LIBS += -L /opt/local/lib -lpthread -ltiff -lexiv2 -ljpeg -lraw_r /opt/local/lib/libiomp5.dylib -lrtprocess
 
 QT += sql core quick qml widgets
 

--- a/filmulator-gui/main.cpp
+++ b/filmulator-gui/main.cpp
@@ -96,14 +96,14 @@ int main(int argc, char *argv[])
     if( appdir )
     {
         QString qmlfile = appdir;
-        qmlfile += "/usr/qml/main.qml";
+        qmlfile += "/Contents/Resources/qml/filmulator-gui/main.qml";
         if (QFile(qmlfile).exists())
         {
             cout << "loading UI from copy in appdir directory" << endl;
             engine.load(qmlfile);
         }
     } 
-    else if (QFile("qml/filmulator-gui/main.qml").exists())
+    else if (QFile("$HOME/filmulator-gui/filmulator-gui/Filmulator.app/Contents/Resources/qml/filmulator-gui/main.qml").exists())
     {
         cout << "loading UI from copy in directory" << endl;
         engine.load("qml/filmulator-gui/main.qml");


### PR DESCRIPTION
My new build system is with `AppleClang 10` on macOS 10.14 _Mojave_, a side-grade from the `clang++-mp-3.9` I was using before on 10.12 _Sierra_, requiring a couple of changes.

The qmlfile changes in `main.cpp` I had made earlier on the _Sierra_ builds, which allow the program to launch.