### PR TITLE
#include <array> for clang compilation

### DIFF
--- a/filmulator-gui/core/whiteBalance.cpp
+++ b/filmulator-gui/core/whiteBalance.cpp
@@ -2,6 +2,7 @@
 #include <utility>
 #include <iostream>
 #include <omp.h>
+#include <array>
 
 using std::cout;
 using std::endl;


### PR DESCRIPTION
Clang requires an include for the array functions. (AppleClang 10)