### PR TITLE
Fix compilation on MacOS

### DIFF
--- a/filmulator-gui/database/camconst.cpp
+++ b/filmulator-gui/database/camconst.cpp
@@ -1,3 +1,4 @@
+#include <cmath>
 #include <string>
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
First of all, this software is awesome, thank you for developing it!

I am running on MacOS 10.14.6, using _Apple LLVM version 10.0.1 (clang-1001.0.46.4)_.
There was an ambiguous definition of `abs` when compiling `filmulator-gui/database/camconst.cpp`, due to a missing header file:

```
filmulator-gui/filmulator-gui/database/camconst.cpp:209:45: error: call to 'abs' is ambiguous
                                        if (abs(isoItem->valuedouble - iso) < 3)
                                            ^~~
/Library/Developer/CommandLineTools/SDKs/MacOSX10.14.sdk/usr/include/stdlib.h:132:6: note: candidate function
int      abs(int) __pure2;
         ^
/Library/Developer/CommandLineTools/usr/include/c++/v1/stdlib.h:111:44: note: candidate function
inline _LIBCPP_INLINE_VISIBILITY long      abs(     long __x) _NOEXCEPT {return  labs(__x);}
                                           ^
/Library/Developer/CommandLineTools/usr/include/c++/v1/stdlib.h:113:44: note: candidate function
inline _LIBCPP_INLINE_VISIBILITY long long abs(long long __x) _NOEXCEPT {return llabs(__x);}
```

the definition of `abs` we need is in `<cmath>`, which this PR adds to the top of the file.