### PR TITLE
Fix crash with noise reduction on MacOS

### DIFF
--- a/filmulator-gui/core/nlmeans/kMeansNLMApprox.cpp
+++ b/filmulator-gui/core/nlmeans/kMeansNLMApprox.cpp
@@ -23,7 +23,10 @@ bool kMeansNLMApprox(float* __restrict const I, const int maxNumClusters, const 
 		ptrdiff_t xBlockStart = blockSize * (blockIdx / numBlocksY);
 		ptrdiff_t yBlockStart = blockSize * (blockIdx % numBlocksY);
 
-		std::array<float, expandedBlockSize * expandedBlockSize * numChannels> IBlockCopy;
+ 		//std::array<float, expandedBlockSize * expandedBlockSize * numChannels> IBlockCopy;
+		std::vector<float> IBlockCopy(expandedBlockSize * expandedBlockSize * numChannels);  // move from stack to global memory (avoid crashes on MacOs, with its small thread stack)
+
+
 		for (ptrdiff_t c = 0; c < numChannels; c++) {
 			for (ptrdiff_t xWriteIdx = 0; xWriteIdx < expandedBlockSize; xWriteIdx++) {
 				for (ptrdiff_t yWriteIdx = 0; yWriteIdx < expandedBlockSize; yWriteIdx++) {
@@ -41,7 +44,9 @@ bool kMeansNLMApprox(float* __restrict const I, const int maxNumClusters, const 
 		}
 
 
-		std::array<float, expandedBlockSize * expandedBlockSize * numChannels * patchSize> expandedDimensions;
+		//std::array<float, expandedBlockSize * expandedBlockSize * numChannels * patchSize> expandedDimensions;
+		std::vector<float> expandedDimensions(expandedBlockSize * expandedBlockSize * numChannels * patchSize);	// move from stack to global memory (avoid crashes on MacOs, with its small thread stack)
+
 		expandDims(IBlockCopy.data(), expandedBlockSize, expandedBlockSize, expandedDimensions.data());
 
 


### PR DESCRIPTION
Activating noise reduction on MacOS causes Filmulator to crash, as it allocates large local data structures in filmulator-gui/core/nlmeans/kMeansNLMApprox.cpp which cause a stack overflow (seems that MacOS just creates very small thread stacks).

This PR fixes the issue by changing the data structures from <array> to <vector>, implicitly allocating them on heap memory. The resulting performance impact should be very small, as the vector sizes are not changed during runtime.

(Personal caveat: I am not a C++ expert nor very experienced with Github etc. - if the PR is considered for merging, please check thoroughly and bear with me if I made stupid mistakes. I did not experience any issues with the modification in my local build, though. Anyway thanks @CarVac for a wonderful piece of SW).