### PR TITLE
Fix build failures from library changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,20 +125,20 @@ if(APPLE)
         ${filmulator_SRCS}
         ${filmulator_RSCS}
     )
-    target_compile_definitions(filmulator PRIVATE LF_GIT)
+    target_compile_definitions(filmulator PRIVATE)
 elseif(WIN32)
     add_executable(filmulator # WIN32 # comment out WIN32 to get a terminal window
         ${filmulator_SRCS}
         ${filmulator_RSCS}
     )
     target_link_directories(filmulator PRIVATE ${GLIB2_LIBRARY_DIRS})
-    target_compile_definitions(filmulator PRIVATE LF_GIT)
+    target_compile_definitions(filmulator PRIVATE)
 else()
     add_executable(filmulator
         ${filmulator_SRCS}
         ${filmulator_RSCS}
     )
-    target_compile_definitions(filmulator PRIVATE LF_GIT)
+    target_compile_definitions(filmulator PRIVATE)
 endif()
 
 target_compile_options(filmulator

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ libexiv2
 libjpeg
 libraw
 librtprocess 0.10
-liblensfun 0.3.95 exactly for Windows, and the latest git version for Linux and MacOS
+liblensfun 0.3.4
 libcurl
 libarchive
 ```

--- a/filmulator-gui/core/imagePipeline.cpp
+++ b/filmulator-gui/core/imagePipeline.cpp
@@ -1206,7 +1206,7 @@ matrix<unsigned short>& ImagePipeline::processImage(ParameterManager * paramMana
 
         //Lensfun processing
         cout << "lensfun start" << endl;
-        lfDatabase *ldb = lf_db_create();
+        lfDatabase *ldb = lf_db_new();
         QDir dir = QDir::home();
         QString dirstr = QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation);
         dirstr.append("/filmulator/version_2");
@@ -1253,39 +1253,27 @@ matrix<unsigned short>& ImagePipeline::processImage(ParameterManager * paramMana
                 lens = lensList[0];
 
                 //Now we set up the modifier itself with the lens and processing flags
-#ifdef LF_GIT
-                lfModifier * mod = new lfModifier(lens, prefilmParam.focalLength, cropFactor, width, height, LF_PF_F32);
-#else //lensfun v0.3.95
-                lfModifier * mod = new lfModifier(cropFactor, width, height, LF_PF_F32);
-#endif
+                lfModifier * mod = new lfModifier(lens, cropFactor, width, height);
 
-                int modflags = 0;
+                int flags = 0;
                 if (prefilmParam.lensfunCA && !isMonochrome)
                 {
-#ifdef LF_GIT
-                    modflags |= mod->EnableTCACorrection();
-#else //lensfun v0.3.95
-                    modflags |= mod->EnableTCACorrection(lens, prefilmParam.focalLength);
-#endif
+                    flags |= LF_MODIFY_TCA;
                 }
                 if (prefilmParam.lensfunVignetting)
                 {
-#ifdef LF_GIT
-                    modflags |= mod->EnableVignettingCorrection(prefilmParam.fnumber, 1000.0f);
-#else //lensfun v0.3.95
-                    modflags |= mod->EnableVignettingCorrection(lens, prefilmParam.focalLength, demosaicParam.fnumber, 1000.0f);
-#endif
+                    flags |= LF_MODIFY_VIGNETTING;
                 }
                 if (prefilmParam.lensfunDistortion)
                 {
-#ifdef LF_GIT
-                    modflags |= mod->EnableDistortionCorrection();
-#else //lensfun v0.3.95
-                    modflags |= mod->EnableDistortionCorrection(lens, prefilmParam.focalLength);
-#endif
-                    modflags |= mod->EnableScaling(mod->GetAutoScale(false));
+                    flags |= LF_MODIFY_DISTORTION | LF_MODIFY_SCALE;
                     cout << "Auto scale factor: " << mod->GetAutoScale(false) << endl;
                 }
+
+                float scale = (flags & LF_MODIFY_SCALE) ? mod->GetAutoScale(false) : 1.0f;
+                mod->Initialize(lens, LF_PF_F32, prefilmParam.focalLength,
+                                               prefilmParam.fnumber, 1000.0f, scale,
+                                               LF_RECTILINEAR, flags, false);
 
                 //Now we actually perform the required processing.
                 //First is vignetting.

--- a/filmulator-gui/core/imwriteJpeg.cpp
+++ b/filmulator-gui/core/imwriteJpeg.cpp
@@ -186,7 +186,7 @@ static void remove_exif_keys(Exiv2::ExifData &exifData, const char *keys[], unsi
             {
                 exifData.erase(pos);
             }
-        } catch (Exiv2::AnyError &e) {
+        } catch (Exiv2::Error &e) {
             //catch invalid tag
         }
     }

--- a/filmulator-gui/database/exifFunctions.cpp
+++ b/filmulator-gui/database/exifFunctions.cpp
@@ -129,7 +129,7 @@ int exifDefaultRotation(const std::string fullFilename)
         int exifOrientation;
         try
         {
-            exifOrientation = (int) exifData["Exif.Image.Orientation"].value().toLong();
+            exifOrientation = (int) exifData["Exif.Image.Orientation"].value().toInt64();
         }
         catch (...)
         {
@@ -301,7 +301,7 @@ int exifRating(const std::string fullFilename)
         std::string maker = exifData["Exif.Image.Make"].toString();
         if (maker.compare("Canon") == 0)
         {
-            return min(5,max(0,(int) xmpData["Xmp.xmp.Rating"].toLong()));
+            return min(5,max(0,(int) xmpData["Xmp.xmp.Rating"].toInt64()));
         }
         return 0;
     }
@@ -518,7 +518,7 @@ QString identifyLens(const std::string fullFilename)
         return "";
     }
 
-    lfDatabase *ldb = lf_db_create();
+    lfDatabase *ldb = lf_db_new();
     QDir dir = QDir::home();
     QString dirstr = QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation);
     dirstr.append("/filmulator/version_2");

--- a/filmulator-gui/filmulator-gui.pro
+++ b/filmulator-gui/filmulator-gui.pro
@@ -146,7 +146,7 @@ HEADERS += \
     database/database.hpp
 
 
-QMAKE_CXXFLAGS += -std=c++17 -DTOUT -O3 -fopenmp -fprefetch-loop-arrays -fno-strict-aliasing -ffast-math -DLF_GIT
+QMAKE_CXXFLAGS += -std=c++17 -DTOUT -O3 -fopenmp -fprefetch-loop-arrays -fno-strict-aliasing -ffast-math
 macx: {
 QMAKE_CXXFLAGS += -Xpreprocessor -lomp -I/opt/local/include
 }

--- a/filmulator-gui/ui/lensSelectModel.cpp
+++ b/filmulator-gui/ui/lensSelectModel.cpp
@@ -26,7 +26,7 @@ LensSelectModel::LensSelectModel(QObject *parent) : QAbstractTableModel(parent)
     dirstr.append("/filmulator/version_2");
     std::string stdstring = dirstr.toStdString();
 
-    ldb = lf_db_create();
+    ldb = lf_db_new();
     if (!ldb)
     {
         cout << "Failed to create database!" << endl;

--- a/filmulator-gui/ui/parameterManager.cpp
+++ b/filmulator-gui/ui/parameterManager.cpp
@@ -53,7 +53,7 @@ ParameterManager::ParameterManager() : QObject(0)
     cout << "ParamManager directory string: " << stdstring << endl;
 
     cout << "ParamManager initializing lensfun db" << endl;
-    ldb = lf_db_create();
+    ldb = lf_db_new();
     if (!ldb)
     {
         cout << "Failed to create database!" << endl;
@@ -4020,28 +4020,10 @@ void ParameterManager::updateLensfunAvailability()
             if (lensList)
             {
 
-                auto calibrationSet = lensList[0]->GetCalibrationSets();
-
-                int i = 0;
-                while (calibrationSet[i])
-                {
-                    auto c = calibrationSet[i];
-                    const float r = cropFactor / c->Attributes.CropFactor;
-                    if ((r >= 0.96) || (cropFactor < 1e-6f))
-                    {
-                        lensfunCaAvail   = (c->HasTCA() && !isMonochrome);
-                        lensfunVignAvail = (c->HasVignetting());
-                        lensfunDistAvail = (c->HasDistortion());
-                    }
-                    i++;
-                }
-
-                //The latter function is only available in lensfun master, not lensfun 3.95
-                // So I duplicated its functionality above.
-                //const int availableMods = lensList[0]->AvailableModifications(cropFactor);
-                //lensfunCaAvail   = (availableMods & LF_MODIFY_TCA) && !isMonochrome;
-                //lensfunVignAvail = availableMods & LF_MODIFY_VIGNETTING;
-                //lensfunDistAvail = availableMods & LF_MODIFY_DISTORTION;
+                const lfLens *lens = lensList[0];
+                lensfunCaAvail   = (lens->CalibTCA && lens->CalibTCA[0] && !isMonochrome);
+                lensfunVignAvail = (lens->CalibVignetting && lens->CalibVignetting[0]);
+                lensfunDistAvail = (lens->CalibDistortion && lens->CalibDistortion[0]);
                 emit lensfunCaAvailChanged();
                 emit lensfunVignAvailChanged();
                 emit lensfunDistAvailChanged();


### PR DESCRIPTION
ran into some dependency issues building, looks like in the last few years some libraries have changed.

fixes for the following exiv2 api chanegs:
- toLong replaced with toInt64 https://github.com/Exiv2/exiv2/pull/2062
- AnyError renamted to Error https://github.com/Exiv2/exiv2/pull/2141

downgraded lensfun 0.3.95 -> 0.3.4. This is more of an opinionated change but it's probably best to use lensfun 0.3.4, they never shipped a stable version of 0.3.95 and in the meantime the rest of the ecosystem has settled on 0.3.4 with continual updates to the database. For what it's worth rawtherapee, digikam, and darktable all link against 0.3.4 and every distro ships 0.3.4 with the latest lens db.

haven't made the appropriate changes to CI but it looks like this is already failing for other reasons